### PR TITLE
Always run an example code with the latest version of thinreports

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -36,10 +36,7 @@ Thinreportsでは、一覧表を一つの機能として提供しており最大
 
 ## Usage Examples
 
-### Rails Examples
-
-* [Rails4](https://github.com/thinreports/thinreports-rails4-example)
-* [Rails3](https://github.com/thinreports/thinreports-rails3-example)
+### [Rails Example](https://github.com/thinreports/thinreports-rails-example)
 
 RailsとThinreportsを使った簡単なタスク管理アプリケーションのソースコードです。 [thinreports-rails](https://github.com/takeshinoda/thinreports-rails) も使っています。
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,7 @@ Methods for encrypting, setting password locks and setting security and restrict
 
 ## Usage Examples
 
-### Rails Examples
-
-* [Rails4](https://github.com/thinreports/thinreports-rails4-example)
-* [Rails3](https://github.com/thinreports/thinreports-rails3-example)
+### [Rails Example](https://github.com/thinreports/thinreports-rails-example)
 
 The links provide the source code to a simple task management application using Rails and Thinreports.  The [thinreports-rails](https://github.com/takeshinoda/thinreports-rails) gem is used in these projects.
 

--- a/barcode/Gemfile
+++ b/barcode/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'thinreports', '0.9.0'
+gem 'thinreports'
 gem 'barby'
 gem 'rqrcode'
 gem 'chunky_png'

--- a/chart/Gemfile
+++ b/chart/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'thinreports', '0.9.0'
+gem 'thinreports'

--- a/chart/chart.rb
+++ b/chart/chart.rb
@@ -5,7 +5,7 @@ require 'open-uri'
 Bundler.require
 
 def open_chart(*params)
-  open('http://chart.googleapis.com/chart?' + URI.encode(params.join('&')))
+  URI.open('http://chart.googleapis.com/chart?' + URI.encode(params.join('&')))
 end
 
 report = Thinreports::Report.new layout: 'chart.tlf'

--- a/estimate-ja/Gemfile
+++ b/estimate-ja/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'thinreports', '0.9.0'
+gem 'thinreports'

--- a/estimate/Gemfile
+++ b/estimate/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'thinreports', '0.9.0'
+gem 'thinreports'

--- a/eudc/Gemfile
+++ b/eudc/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'thinreports', '0.9.0'
+gem 'thinreports'

--- a/event/Gemfile
+++ b/event/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'thinreports', '0.9.0'
+gem 'thinreports'

--- a/image-block/Gemfile
+++ b/image-block/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'thinreports', '0.9.0'
+gem 'thinreports'

--- a/image-block/image_block.rb
+++ b/image-block/image_block.rb
@@ -11,7 +11,7 @@ require 'stringio'
 report = Thinreports::Report.new layout: 'image_block.tlf'
 report.start_new_page do |page|
   page.item(:local_image).src('file/image.png')
-  page.item(:remote_image).value(open('http://www.thinreports.org/assets/logos/thinreports-logo-v.png'))
+  page.item(:remote_image).value(URI.open('http://www.thinreports.org/assets/logos/thinreports-logo-v.png'))
 
   red_dot = 'iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4' +
             '//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=='

--- a/list/advanced/Gemfile
+++ b/list/advanced/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'thinreports', '0.9.0'
+gem 'thinreports'

--- a/list/basic/Gemfile
+++ b/list/basic/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'thinreports', '0.9.0'
+gem 'thinreports'

--- a/list/group-rows/Gemfile
+++ b/list/group-rows/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'thinreports', '0.9.0'
+gem 'thinreports'

--- a/multiple-layout/Gemfile
+++ b/multiple-layout/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'thinreports', '0.9.0'
+gem 'thinreports'

--- a/permission/Gemfile
+++ b/permission/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'thinreports', '0.9.0'
+gem 'thinreports'

--- a/text-block/Gemfile
+++ b/text-block/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'thinreports', '0.9.0'
+gem 'thinreports'


### PR DESCRIPTION
現状、thinreports をリリースするたびに、各 example の依存バージョンを書き換えなくてはならない。これは効率が悪すぎるので、依存バージョンの指定を削除し常に最新バージョンを使うようにします。

ついでに、https://github.com/thinreports/thinreports-examples/commit/6d27bca21c9b05c098148b485ddea456a0e6e2ad で Rails Example へのリンク先も差し替えました。